### PR TITLE
fix DIA_SDK_INCLUDE_DIR

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -1,23 +1,38 @@
-set(SourceFiles
-    "HyperDbgIntegration.cpp"
-    "main.cpp"
-    "PDB.cpp"
-    "PDBExtractor.cpp"
-    "PDBHeaderReconstructor.cpp"
-    "HyperDbgExport.h"
-    "HyperDbgGlobals.h"
-    "PDB.h"
-    "PDBCallback.h"
-    "PDBExtractor.h"
-    "PDBHeaderReconstructor.h"
-    "PDBReconstructorBase.h"
-    "PDBSymbolSorterAlphabetical.h"
-    "PDBSymbolSorterBase.h"
-    "PDBSymbolVisitorBase.h"
-    "PDBSymbolVisitor.h"
-    "PDBSymbolSorter.h"
-    "UdtFieldDefinition.h"
-    "UdtFieldDefinitionBase.h"
+find_path(DIA_SDK_INCLUDE_DIR
+        NAMES dia2.h
+        PATHS
+        "$ENV{VSINSTALLDIR}/DIA SDK/include"
+        "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/DIA SDK/include"
+        "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/DIA SDK/include"
+        DOC "Path to DIA SDK include directory"
 )
-include_directories( "DIA SDK/include" )
+
+if(DIA_SDK_INCLUDE_DIR)
+    include_directories(${DIA_SDK_INCLUDE_DIR})
+    message(STATUS "Found DIA SDK include directory: ${DIA_SDK_INCLUDE_DIR}")
+else()
+    message(FATAL_ERROR "Could not find DIA SDK include directory")
+endif()
+
+set(SourceFiles
+        "HyperDbgIntegration.cpp"
+        "main.cpp"
+        "PDB.cpp"
+        "PDBExtractor.cpp"
+        "PDBHeaderReconstructor.cpp"
+        "HyperDbgExport.h"
+        "HyperDbgGlobals.h"
+        "PDB.h"
+        "PDBCallback.h"
+        "PDBExtractor.h"
+        "PDBHeaderReconstructor.h"
+        "PDBReconstructorBase.h"
+        "PDBSymbolSorterAlphabetical.h"
+        "PDBSymbolSorterBase.h"
+        "PDBSymbolVisitorBase.h"
+        "PDBSymbolVisitor.h"
+        "PDBSymbolSorter.h"
+        "UdtFieldDefinition.h"
+        "UdtFieldDefinitionBase.h"
+)
 add_library(pdbex SHARED ${SourceFiles})


### PR DESCRIPTION
====================[ Build | pdbex | Debug ]===================================
"C:\Program Files\JetBrains\CLion 2024.1.2\bin\cmake\win\x64\bin\cmake.exe" --build D:\HyperDbg\hyperdbg\cmake-build-debug --target pdbex -j 6
[0/1] Re-running CMake...
-- WDK_ROOT: C:/Program Files (x86)/Windows Kits/10
-- WDK_VERSION: 10.0.26100.0
-- Found DIA SDK include directory: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/DIA SDK/include
-- Configuring done (0.1s)
-- Generating done (0.1s)
-- Build files have been written to: D:/HyperDbg/hyperdbg/cmake-build-debug
[1/7] Building CXX object dependencies\pdbex\Source\CMakeFiles\pdbex.dir\PDB.cpp.obj
[2/7] Building CXX object dependencies\pdbex\Source\CMakeFiles\pdbex.dir\PDBHeaderReconstructor.cpp.obj
[3/7] Building CXX object dependencies\pdbex\Source\CMakeFiles\pdbex.dir\HyperDbgIntegration.cpp.obj
[4/7] Building CXX object dependencies\pdbex\Source\CMakeFiles\pdbex.dir\main.cpp.obj
[5/7] Building CXX object dependencies\pdbex\Source\CMakeFiles\pdbex.dir\PDBExtractor.cpp.obj
[6/7] Linking CXX shared library dependencies\pdbex\Source\pdbex.dll

Build finished
